### PR TITLE
Revert: Going Back to Creating a Separate Build

### DIFF
--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_ios_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_ios_action.rb
@@ -17,7 +17,7 @@ module Fastlane
         end
 
         boot_ios_simulator(params)
-        install_ios_app(params)
+        build_and_install_ios_app(params)
 
         UI.message("Running Maestro tests on iOS...")
 
@@ -68,7 +68,23 @@ module Fastlane
         end
       end
 
-      def self.install_ios_app(params)
+      def self.build_and_install_ios_app(params)
+        UI.message("Building iOS app with scheme: #{params[:scheme]}")
+        other_action.gym(
+          workspace: params[:workspace],
+          scheme: params[:scheme],
+          destination: "platform=iOS Simulator,name=#{params[:simulator_name]}",
+          configuration: "Release",
+          clean: true,
+          sdk: "iphonesimulator",
+          build_path: "./build",
+          skip_archive: true,
+          skip_package_ipa: true,
+          include_symbols: false,
+          include_bitcode: false,
+          xcargs: "-UseModernBuildSystem=YES"
+        )
+
         derived_data_path = File.expand_path("~/Library/Developer/Xcode/DerivedData")
         app_path = Dir["#{derived_data_path}/**/Release-iphonesimulator/#{params[:scheme]}.app"].first
 


### PR DESCRIPTION
- Checked the logs of `build_ios` workflow for bluetooth app, and looks like we can't go around the architecture issue (at least to the extent of my knowledge and what I found online), so we have to create a separate build.
- To support this, here is an example of me manipulating `.ipa` file which should contain `.app` file in itself, so the procedure for extracting it is:
1. Convert `.ipa` to `.zip`
2. Extract `.zip`
3. cd into extracted folder until you find `.app` file and then try to install it on the `booted` simulator from cli
- As you can see below, this is not exectuable:

https://github.com/user-attachments/assets/5d09e8eb-e987-4ef9-9188-4b0b38cdcbb8


https://github.com/user-attachments/assets/74881878-cfe6-47c8-866c-3e37ee9c073d

Also if you check the logs in the workflow, you can see that we are not building the app for the simulator, but for the devices (check `destination` parameter):
<img width="1047" alt="gym method" src="https://github.com/user-attachments/assets/63e22b2d-3b07-4d32-968c-28abb6f7949f" />

Destination implies architecture: https://github.com/fastlane/fastlane/issues/21138
This one is older, but they were also using two separate builds: https://github.com/fastlane/fastlane/issues/15555