### PR TITLE
Fix: Use fastlane 'adb' action instead of 'sh' command

### DIFF
--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -53,6 +53,7 @@ module Fastlane
       def self.setup_emulator(params)
         sdk_dir = params[:sdk_dir]
         adb = "#{sdk_dir}/platform-tools/adb"
+        avdmanager = Helper::AvdHelper.new
 
         UI.message("Stop all running emulators...")
         devices = other_action.adb(command: "devices", adb_path: adb).split("\n").drop(1)
@@ -72,7 +73,7 @@ module Fastlane
         end
 
         UI.message("Setting up new Android emulator...")
-        system("#{sdk_dir}/cmdline-tools/latest/bin/avdmanager create avd -n '#{params[:emulator_name]}' -f -k '#{params[:emulator_package]}' -d '#{params[:emulator_device]}'")
+        avdmanager.create_avd(name: params[:emulator_name], package: params[:emulator_package], device: params[:emulator_device])
         sleep(5)
 
         UI.message("Starting Android emulator...")

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -105,7 +105,8 @@ module Fastlane
         UI.message("Installing Android app...")
 
         adb = Helper::AdbHelper.new
-        apk_path = Dir["app/build/outputs/apk/release/app-release.apk"].first
+        apk_path = Dir["app/build/outputs/apk/release/*.apk"].first
+        UI.success("APK path: #{apk_path}")
 
         if apk_path.nil?
           UI.user_error!("Error: APK file not found in build outputs.")

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -52,7 +52,7 @@ module Fastlane
       end
 
       def self.setup_emulator(params)
-        sdk_dir = params[:sdk_dir]
+        emulator = Helper::EmulatorHelper.new
         adb = Helper::AdbHelper.new
         avdmanager = Helper::AvdHelper.new
 
@@ -78,7 +78,7 @@ module Fastlane
         sleep(5)
 
         UI.message("Starting Android emulator...")
-        system("#{sdk_dir}/emulator/emulator -avd #{params[:emulator_name]} -port #{params[:emulator_port]} > /dev/null 2>&1 &")
+        emulator.start_emulator(name: params[:emulator_name], port: params[:emulator_port])
         adb.trigger(command: "wait-for-device")
 
         sleep(5) while adb.trigger(command: "shell getprop sys.boot_completed").strip != "1"

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -85,16 +85,18 @@ module Fastlane
       end
 
       def self.demo_mode(params)
+        adb = "#{params[:sdk_dir]}/platform-tools/adb"
+
         UI.message("Checking and allowing demo mode on Android emulator...")
-        sh("#{params[:sdk_dir]}/platform-tools/adb shell settings put global sysui_demo_allowed 1")
-        sh("#{params[:sdk_dir]}/platform-tools/adb shell settings get global sysui_demo_allowed")
+        other_action.adb(command: "shell settings put global sysui_demo_allowed 1", adb_path: adb)
+        other_action.adb(command: "shell settings get global sysui_demo_allowed", adb_path: adb)
 
         UI.message("Setting demo mode commands...")
-        sh("#{params[:sdk_dir]}/platform-tools/adb shell am broadcast -a com.android.systemui.demo -e command enter")
-        sh("#{params[:sdk_dir]}/platform-tools/adb shell am broadcast -a com.android.systemui.demo -e command clock -e hhmm 1200")
-        sh("#{params[:sdk_dir]}/platform-tools/adb shell am broadcast -a com.android.systemui.demo -e command battery -e level 100")
-        sh("#{params[:sdk_dir]}/platform-tools/adb shell am broadcast -a com.android.systemui.demo -e command network -e wifi show -e level 4")
-        sh("#{params[:sdk_dir]}/platform-tools/adb shell am broadcast -a com.android.systemui.demo -e command network -e mobile show -e datatype none -e level 4")
+        other_action.adb(command: "shell am broadcast -a com.android.systemui.demo -e command enter", adb_path: adb)
+        other_action.adb(command: "shell am broadcast -a com.android.systemui.demo -e command clock -e hhmm 1200", adb_path: adb)
+        other_action.adb(command: "shell am broadcast -a com.android.systemui.demo -e command battery -e level 100", adb_path: adb)
+        other_action.adb(command: "shell am broadcast -a com.android.systemui.demo -e command network -e wifi show -e level 4", adb_path: adb)
+        other_action.adb(command: "shell am broadcast -a com.android.systemui.demo -e command network -e mobile show -e datatype none -e level 4", adb_path: adb)
       end
 
       def self.install_android_app(params)

--- a/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
@@ -31,8 +31,6 @@ module Fastlane
           available_path = Dir.glob(File.join(cmdline_tools_path, "*", "bin")).first
           raise "No valid bin path found in #{cmdline_tools_path}" unless available_path
 
-          UI.message("Available BIN path: #{available_path}")
-
           avdmanager_path = File.join(available_path, "avdmanager")
         end
 

--- a/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
@@ -56,5 +56,42 @@ module Fastlane
         trigger(command: command)
       end
     end
+
+    class EmulatorHelper
+      attr_accessor :emulator_path
+
+      def initialize(emulator_path: nil)
+        android_home = ENV.fetch('ANDROID_HOME', nil) || ENV.fetch('ANDROID_SDK_ROOT', nil)
+        if (emulator_path.nil? || emulator_path == "avdmanager") && android_home
+          emulator_path = File.join(android_home, "emulator", "emulator")
+        end
+        UI.message("This is the emulator path: #{emulator_path}")
+
+        self.emulator_path = Helper.get_executable_path(File.expand_path(emulator_path))
+      end
+
+      def trigger(command: nil)
+        raise "emulator_path is not set" unless emulator_path
+
+        # Build and execute the command
+        command = [emulator_path.shellescape, command].compact.join(" ").strip
+        Action.sh(command)
+      end
+
+      # Start an emulator instance
+      def start_emulator(name:, port:)
+        raise "Emulator name is required" if name.nil? || name.empty?
+        raise "Port is required" if port.nil? || port.to_s.empty?
+
+        command = [
+          "-avd #{name.shellescape}",
+          "-port #{port.shellescape}",
+          "> /dev/null 2>&1 &"
+        ].join(" ")
+
+        UI.message("Starting emulator #{name} on port #{port}...")
+        trigger(command: command)
+      end
+    end
   end
 end

--- a/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
@@ -24,7 +24,16 @@ module Fastlane
       def initialize(avdmanager_path: nil)
         android_home = ENV.fetch('ANDROID_HOME', nil) || ENV.fetch('ANDROID_SDK_ROOT', nil)
         if (avdmanager_path.nil? || avdmanager_path == "avdmanager") && android_home
-          avdmanager_path = File.join(android_home, "cmdline-tools", "latest", "bin", "avdmanager")
+          # First search for cmdline-tools dir
+          cmdline_tools_path = File.join(android_home, "cmdline-tools")
+
+          # Find the first available 'bin' folder within cmdline-tools
+          available_path = Dir.glob(File.join(cmdline_tools_path, "*", "bin")).first
+          raise "No valid bin path found in #{cmdline_tools_path}" unless available_path
+
+          UI.message("Available BIN path: #{available_path}")
+
+          avdmanager_path = File.join(available_path, "avdmanager")
         end
 
         self.avdmanager_path = Helper.get_executable_path(File.expand_path(avdmanager_path))

--- a/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
@@ -1,7 +1,9 @@
 require 'fastlane_core/ui/ui'
+require 'fastlane/action'
 
 module Fastlane
   UI = FastlaneCore::UI unless Fastlane.const_defined?(:UI)
+  Helper = FastlaneCore::Helper unless Fastlane.const_defined?(:Helper)
 
   module Helper
     class MaestroOrchestrationHelper
@@ -10,6 +12,48 @@ module Fastlane
       #
       def self.show_message
         UI.message("Hello from the maestro_orchestration plugin helper!")
+      end
+    end
+
+    class AvdHelper
+      # Path to the avd binary
+      attr_accessor :avdmanager_path
+      # Available AVDs
+      attr_accessor :avds
+
+      def initialize(avdmanager_path: nil)
+        android_home = ENV.fetch('ANDROID_HOME', nil) || ENV.fetch('ANDROID_SDK_ROOT', nil)
+        if (avdmanager_path.nil? || avdmanager_path == "avdmanager") && android_home
+          avdmanager_path = File.join(android_home, "cmdline-tools", "latest", "bin", "avdmanager")
+        end
+
+        self.avdmanager_path = Helper.get_executable_path(File.expand_path(avdmanager_path))
+      end
+
+      def trigger(command: nil)
+        raise "avdmanager_path is not set" unless avdmanager_path
+
+        # Build and execute the command
+        command = [avdmanager_path.shellescape, command].compact.join(" ").strip
+        Action.sh(command)
+      end
+
+      # Create a new AVD
+      def create_avd(name:, package:, device: "pixel_7_pro")
+        raise "AVD name is required" if name.nil? || name.empty?
+        raise "System image package is required" if package.nil? || package.empty?
+
+        UI.message("This is the package parameter passed: #{package}")
+
+        command = [
+          "create avd",
+          "-n #{name.shellescape}",
+          "-f",
+          "-k \"#{package}\"",
+          "-d #{device.shellescape}"
+        ].join(" ")
+
+        trigger(command: command)
       end
     end
   end


### PR DESCRIPTION
- Using `adb` action instead of `sh`. However, we still have to pass `adb_path`. 
- I added reading the `sdk_path` from the ENV, to first check for `ANDROID_HOME` or `ANDROID_SDK_ROOT`, and only then it defaults to `~/Library/Android/sdk`. It will save us some trouble if we end up redoing `android-command-line-tools` installation, but even if we don't go that way it's still helpful for others.

As an example, I am using all my sdk tools with homebrew (setup where all the tools are in `~/Library/Android/sdk/android-commandlinetools`, so I just added $ANDROID_HOME path. 
![path](https://github.com/user-attachments/assets/d1b1a170-49c3-4131-872e-3de29712137a)

I am passing ENV['ANDROID_HOME'] here, but I assume we can do it in CI/CD as well, so it doesn't have to be in here.
![maestro](https://github.com/user-attachments/assets/95911c5d-563b-41b5-a231-900cda53d1a2)
