### PR TITLE
Feat: Make sure the plugin works with .aab builds

### DIFF
--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -106,40 +106,40 @@ module Fastlane
 
         adb = Helper::AdbHelper.new
         apk_path = Dir["app/build/outputs/apk/release/*.apk"].first
-        
+
         if apk_path.nil?
           UI.message("APK file not found. Checking for AAB file...")
-      
+
           # Dynamically check for any AAB in the bundle release output directory
           aab_path = Dir["app/build/outputs/bundle/release/*.aab"].first
-      
+
           if aab_path.nil?
             UI.user_error!("Error: Neither APK nor AAB file found in build outputs.")
           end
-      
+
           UI.message("Found AAB file at: #{aab_path}")
           # Path to bundletool
           bundletool_path = "path/to/bundletool.jar" # Replace with your bundletool path
           output_apks = "app/build/outputs/bundle/release/output.apks"
-      
+
           # Generate APKs using bundletool
           UI.message("Generating APK from AAB using bundletool...")
           system("java -jar #{bundletool_path.shellescape} build-apks --bundle=#{aab_path.shellescape} --output=#{output_apks.shellescape} --mode=universal > /dev/null 2>&1")
-      
+
           # Check if the APK set was generated
           unless File.exist?(output_apks)
             UI.user_error!("Error: Failed to generate APK from AAB using bundletool.")
           end
-      
+
           UI.message("APKs generated at: #{output_apks}")
           UI.message("Extracting universal APK from APK set...")
           system("unzip -o #{output_apks.shellescape} -d app/build/outputs/bundle/release/ > /dev/null 2>&1")
           universal_apk = Dir["app/build/outputs/bundle/release/universal.apk"].first
-      
+
           unless universal_apk
             UI.user_error!("Error: Universal APK not found in APK set.")
           end
-      
+
           UI.message("Universal APK extracted at: #{universal_apk}")
           apk_path = universal_apk
         end

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -53,6 +53,7 @@ module Fastlane
       def self.setup_emulator(params)
         sdk_dir = params[:sdk_dir]
         adb = "#{sdk_dir}/platform-tools/adb"
+        avdmanager = Helper::AvdHelper.new
 
         UI.message("Stop all running emulators...")
         devices = other_action.adb(command: "devices", adb_path: adb).split("\n").drop(1)
@@ -72,7 +73,7 @@ module Fastlane
         end
 
         UI.message("Setting up new Android emulator...")
-        system("#{sdk_dir}/cmdline-tools/latest/bin/avdmanager create avd -n '#{params[:emulator_name]}' -f -k '#{params[:emulator_package]}' -d '#{params[:emulator_device]}'")
+        avdmanager.create_avd(name: params[:emulator_name], package: params[:emulator_package], device: params[:emulator_device])
         sleep(5)
 
         UI.message("Starting Android emulator...")

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -106,13 +106,46 @@ module Fastlane
 
         adb = Helper::AdbHelper.new
         apk_path = Dir["app/build/outputs/apk/release/*.apk"].first
-        UI.success("APK path: #{apk_path}")
-
+        
         if apk_path.nil?
-          UI.user_error!("Error: APK file not found in build outputs.")
+          UI.message("APK file not found. Checking for AAB file...")
+      
+          # Dynamically check for any AAB in the bundle release output directory
+          aab_path = Dir["app/build/outputs/bundle/release/*.aab"].first
+      
+          if aab_path.nil?
+            UI.user_error!("Error: Neither APK nor AAB file found in build outputs.")
+          end
+      
+          UI.message("Found AAB file at: #{aab_path}")
+          # Path to bundletool
+          bundletool_path = "path/to/bundletool.jar" # Replace with your bundletool path
+          output_apks = "app/build/outputs/bundle/release/output.apks"
+      
+          # Generate APKs using bundletool
+          UI.message("Generating APK from AAB using bundletool...")
+          system("java -jar #{bundletool_path.shellescape} build-apks --bundle=#{aab_path.shellescape} --output=#{output_apks.shellescape} --mode=universal > /dev/null 2>&1")
+      
+          # Check if the APK set was generated
+          unless File.exist?(output_apks)
+            UI.user_error!("Error: Failed to generate APK from AAB using bundletool.")
+          end
+      
+          UI.message("APKs generated at: #{output_apks}")
+          UI.message("Extracting universal APK from APK set...")
+          system("unzip -o #{output_apks.shellescape} -d app/build/outputs/bundle/release/ > /dev/null 2>&1")
+          universal_apk = Dir["app/build/outputs/bundle/release/universal.apk"].first
+      
+          unless universal_apk
+            UI.user_error!("Error: Universal APK not found in APK set.")
+          end
+      
+          UI.message("Universal APK extracted at: #{universal_apk}")
+          apk_path = universal_apk
         end
 
-        UI.message("Found APK file at: #{apk_path}")
+        # Install the APK
+        UI.message("Installing APK: #{apk_path}")
         adb.trigger(command: "install -r '#{apk_path}'")
         UI.success("APK installed on Android emulator.")
       end

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -105,7 +105,8 @@ module Fastlane
         UI.message("Installing Android app...")
 
         adb = Helper::AdbHelper.new
-        apk_path = Dir["app/build/outputs/apk/release/app-release.apk"].first
+        apk_path = Dir["app/build/outputs/apk/release/*.apk"].first
+        UI.success("APK path: #{apk_path}")
 
         if apk_path.nil?
           UI.user_error!("Error: APK file not found in build outputs.")

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -52,7 +52,7 @@ module Fastlane
       end
 
       def self.setup_emulator(params)
-        sdk_dir = params[:sdk_dir]
+        emulator = Helper::EmulatorHelper.new
         adb = Helper::AdbHelper.new
         avdmanager = Helper::AvdHelper.new
 
@@ -78,7 +78,7 @@ module Fastlane
         sleep(5)
 
         UI.message("Starting Android emulator...")
-        system("#{sdk_dir}/emulator/emulator -avd #{params[:emulator_name]} -port #{params[:emulator_port]} > /dev/null 2>&1 &")
+        emulator.start_emulator(name: params[:emulator_name], port: params[:emulator_port])
         adb.trigger(command: "wait-for-device")
 
         sleep(5) while adb.trigger(command: "shell getprop sys.boot_completed").strip != "1"

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -85,16 +85,18 @@ module Fastlane
       end
 
       def self.demo_mode(params)
+        adb = "#{params[:sdk_dir]}/platform-tools/adb"
+
         UI.message("Checking and allowing demo mode on Android emulator...")
-        sh("#{params[:sdk_dir]}/platform-tools/adb shell settings put global sysui_demo_allowed 1")
-        sh("#{params[:sdk_dir]}/platform-tools/adb shell settings get global sysui_demo_allowed")
+        other_action.adb(command: "shell settings put global sysui_demo_allowed 1", adb_path: adb)
+        other_action.adb(command: "shell settings get global sysui_demo_allowed", adb_path: adb)
 
         UI.message("Setting demo mode commands...")
-        sh("#{params[:sdk_dir]}/platform-tools/adb shell am broadcast -a com.android.systemui.demo -e command enter")
-        sh("#{params[:sdk_dir]}/platform-tools/adb shell am broadcast -a com.android.systemui.demo -e command clock -e hhmm 1200")
-        sh("#{params[:sdk_dir]}/platform-tools/adb shell am broadcast -a com.android.systemui.demo -e command battery -e level 100")
-        sh("#{params[:sdk_dir]}/platform-tools/adb shell am broadcast -a com.android.systemui.demo -e command network -e wifi show -e level 4")
-        sh("#{params[:sdk_dir]}/platform-tools/adb shell am broadcast -a com.android.systemui.demo -e command network -e mobile show -e datatype none -e level 4")
+        other_action.adb(command: "shell am broadcast -a com.android.systemui.demo -e command enter", adb_path: adb)
+        other_action.adb(command: "shell am broadcast -a com.android.systemui.demo -e command clock -e hhmm 1200", adb_path: adb)
+        other_action.adb(command: "shell am broadcast -a com.android.systemui.demo -e command battery -e level 100", adb_path: adb)
+        other_action.adb(command: "shell am broadcast -a com.android.systemui.demo -e command network -e wifi show -e level 4", adb_path: adb)
+        other_action.adb(command: "shell am broadcast -a com.android.systemui.demo -e command network -e mobile show -e datatype none -e level 4", adb_path: adb)
       end
 
       def self.install_android_app(params)

--- a/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
@@ -31,8 +31,6 @@ module Fastlane
           available_path = Dir.glob(File.join(cmdline_tools_path, "*", "bin")).first
           raise "No valid bin path found in #{cmdline_tools_path}" unless available_path
 
-          UI.message("Available BIN path: #{available_path}")
-
           avdmanager_path = File.join(available_path, "avdmanager")
         end
 

--- a/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
@@ -56,5 +56,42 @@ module Fastlane
         trigger(command: command)
       end
     end
+
+    class EmulatorHelper
+      attr_accessor :emulator_path
+
+      def initialize(emulator_path: nil)
+        android_home = ENV.fetch('ANDROID_HOME', nil) || ENV.fetch('ANDROID_SDK_ROOT', nil)
+        if (emulator_path.nil? || emulator_path == "avdmanager") && android_home
+          emulator_path = File.join(android_home, "emulator", "emulator")
+        end
+        UI.message("This is the emulator path: #{emulator_path}")
+
+        self.emulator_path = Helper.get_executable_path(File.expand_path(emulator_path))
+      end
+
+      def trigger(command: nil)
+        raise "emulator_path is not set" unless emulator_path
+
+        # Build and execute the command
+        command = [emulator_path.shellescape, command].compact.join(" ").strip
+        Action.sh(command)
+      end
+
+      # Start an emulator instance
+      def start_emulator(name:, port:)
+        raise "Emulator name is required" if name.nil? || name.empty?
+        raise "Port is required" if port.nil? || port.to_s.empty?
+
+        command = [
+          "-avd #{name.shellescape}",
+          "-port #{port.shellescape}",
+          "> /dev/null 2>&1 &"
+        ].join(" ")
+
+        UI.message("Starting emulator #{name} on port #{port}...")
+        trigger(command: command)
+      end
+    end
   end
 end

--- a/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
@@ -24,7 +24,16 @@ module Fastlane
       def initialize(avdmanager_path: nil)
         android_home = ENV.fetch('ANDROID_HOME', nil) || ENV.fetch('ANDROID_SDK_ROOT', nil)
         if (avdmanager_path.nil? || avdmanager_path == "avdmanager") && android_home
-          avdmanager_path = File.join(android_home, "cmdline-tools", "latest", "bin", "avdmanager")
+          # First search for cmdline-tools dir
+          cmdline_tools_path = File.join(android_home, "cmdline-tools")
+
+          # Find the first available 'bin' folder within cmdline-tools
+          available_path = Dir.glob(File.join(cmdline_tools_path, "*", "bin")).first
+          raise "No valid bin path found in #{cmdline_tools_path}" unless available_path
+
+          UI.message("Available BIN path: #{available_path}")
+
+          avdmanager_path = File.join(available_path, "avdmanager")
         end
 
         self.avdmanager_path = Helper.get_executable_path(File.expand_path(avdmanager_path))

--- a/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
@@ -1,7 +1,9 @@
 require 'fastlane_core/ui/ui'
+require 'fastlane/action'
 
 module Fastlane
   UI = FastlaneCore::UI unless Fastlane.const_defined?(:UI)
+  Helper = FastlaneCore::Helper unless Fastlane.const_defined?(:Helper)
 
   module Helper
     class MaestroOrchestrationHelper
@@ -10,6 +12,48 @@ module Fastlane
       #
       def self.show_message
         UI.message("Hello from the maestro_orchestration plugin helper!")
+      end
+    end
+
+    class AvdHelper
+      # Path to the avd binary
+      attr_accessor :avdmanager_path
+      # Available AVDs
+      attr_accessor :avds
+
+      def initialize(avdmanager_path: nil)
+        android_home = ENV.fetch('ANDROID_HOME', nil) || ENV.fetch('ANDROID_SDK_ROOT', nil)
+        if (avdmanager_path.nil? || avdmanager_path == "avdmanager") && android_home
+          avdmanager_path = File.join(android_home, "cmdline-tools", "latest", "bin", "avdmanager")
+        end
+
+        self.avdmanager_path = Helper.get_executable_path(File.expand_path(avdmanager_path))
+      end
+
+      def trigger(command: nil)
+        raise "avdmanager_path is not set" unless avdmanager_path
+
+        # Build and execute the command
+        command = [avdmanager_path.shellescape, command].compact.join(" ").strip
+        Action.sh(command)
+      end
+
+      # Create a new AVD
+      def create_avd(name:, package:, device: "pixel_7_pro")
+        raise "AVD name is required" if name.nil? || name.empty?
+        raise "System image package is required" if package.nil? || package.empty?
+
+        UI.message("This is the package parameter passed: #{package}")
+
+        command = [
+          "create avd",
+          "-n #{name.shellescape}",
+          "-f",
+          "-k \"#{package}\"",
+          "-d #{device.shellescape}"
+        ].join(" ")
+
+        trigger(command: command)
       end
     end
   end


### PR DESCRIPTION
This is just a draft, as you can see, `bundletool` is required. It can be downloaded either manually from: https://developer.android.com/tools/bundletool or we can use homebrew as well: https://formulae.brew.sh/formula/bundletool. But now, if we are working on changing ansible playbooks it makes no sense downloading it from here, maybe just checking if it's there?
After we get that done it should be as straightforward as running: `bundletool build-apks --bundle=aab_path.aab --output=release.apks`

What are your thoughts on this approach?