### PR TITLE
Fix: Remove custom logic for 'serial' extraction

### DIFF
--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -18,7 +18,7 @@ module Fastlane
         end
 
         UI.message("Emualtor_device: #{params[:emulator_device]}")
-        UI.message("SDK DIR: #{params[:sdk_dir]}")
+        UI.message("--------------\n\nSDK DIR: #{params[:sdk_dir]}\n\n--------------")
         adb = Helper::AdbHelper.new
         UI.message("ADB: #{adb.adb_path}")
 

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -100,7 +100,6 @@ module Fastlane
 
         UI.message("Setting demo mode commands...")
         adb.trigger(command: "shell am broadcast -a com.android.systemui.demo -e command enter", serial: serial)
-        sleep(3)
         adb.trigger(command: "shell am broadcast -a com.android.systemui.demo -e command clock -e hhmm 1200", serial: serial)
         adb.trigger(command: "shell am broadcast -a com.android.systemui.demo -e command battery -e level 100", serial: serial)
         adb.trigger(command: "shell am broadcast -a com.android.systemui.demo -e command network -e wifi show -e level 4", serial: serial)


### PR DESCRIPTION
- Also fix, added `serial` value to `trigger` method, it was failing sometimes when it couldn't find the value.
- Modify the loop for checking if the emulator is booted, more consistent results when using `sh`.