### PR TITLE
Fix: Demo Modes for iOS and Android

### DIFF
--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -18,7 +18,7 @@ module Fastlane
         end
 
         UI.message("Emualtor_device: #{params[:emulator_device]}")
-        UI.message("SDK DIR: #{params[:sdk_dir]}")
+        UI.message("--------------\n\nSDK DIR: #{params[:sdk_dir]}\n\n--------------")
         adb = Helper::AdbHelper.new
         UI.message("ADB: #{adb.adb_path}")
 

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -100,7 +100,6 @@ module Fastlane
 
         UI.message("Setting demo mode commands...")
         adb.trigger(command: "shell am broadcast -a com.android.systemui.demo -e command enter", serial: serial)
-        sleep(3)
         adb.trigger(command: "shell am broadcast -a com.android.systemui.demo -e command clock -e hhmm 1200", serial: serial)
         adb.trigger(command: "shell am broadcast -a com.android.systemui.demo -e command battery -e level 100", serial: serial)
         adb.trigger(command: "shell am broadcast -a com.android.systemui.demo -e command network -e wifi show -e level 4", serial: serial)

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -102,7 +102,6 @@ module Fastlane
         adb.trigger(command: "shell am broadcast -a com.android.systemui.demo -e command enter", serial: serial)
         adb.trigger(command: "shell am broadcast -a com.android.systemui.demo -e command clock -e hhmm 1200", serial: serial)
         adb.trigger(command: "shell am broadcast -a com.android.systemui.demo -e command battery -e level 100", serial: serial)
-        adb.trigger(command: "shell am broadcast -a com.android.systemui.demo -e command network -e wifi show -e level 4", serial: serial)
       end
 
       def self.install_android_app(params)

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -103,7 +103,6 @@ module Fastlane
         adb.trigger(command: "shell am broadcast -a com.android.systemui.demo -e command clock -e hhmm 1200", serial: serial)
         adb.trigger(command: "shell am broadcast -a com.android.systemui.demo -e command battery -e level 100", serial: serial)
         adb.trigger(command: "shell am broadcast -a com.android.systemui.demo -e command network -e wifi show -e level 4", serial: serial)
-        adb.trigger(command: "shell am broadcast -a com.android.systemui.demo -e command network -e mobile show -e datatype none -e level 4", serial: serial)
       end
 
       def self.install_android_app(params)

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -62,12 +62,12 @@ module Fastlane
           devices.each do |device|
             UI.message("Stopping emulator: #{device.serial}")
             adb.trigger(command: "emu kill", serial: device.serial)
-            sleep(5)
+            sleep(10)
             system("Stopped emulator: #{device.serial}")
           end
         end
         UI.message("Waiting for all emulators to stop...")
-        sleep(5)
+        sleep(10)
 
         UI.message("Setting up new Android emulator...")
         avdmanager.create_avd(name: params[:emulator_name], package: params[:emulator_package], device: params[:emulator_device])

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_ios_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_ios_action.rb
@@ -17,6 +17,7 @@ module Fastlane
         end
 
         boot_ios_simulator(params)
+        demo_mode(params)
         build_and_install_ios_app(params)
 
         UI.message("Running Maestro tests on iOS...")
@@ -66,6 +67,13 @@ module Fastlane
           end
           UI.success("Simulator '#{device_name}' is booted.")
         end
+      end
+
+      def self.demo_mode(params)
+        UI.message("Setting demo mode on #{params[:simulator_name]}...")
+        sh("xcrun simctl status_bar '#{params[:simulator_name]}' override --time '09:30'")
+        sh("xcrun simctl status_bar '#{params[:simulator_name]}' override --batteryState charged --batteryLevel 100")
+        sh("xcrun simctl status_bar '#{params[:simulator_name]}' override --wifiBars 3 --cellularBars 4")
       end
 
       def self.build_and_install_ios_app(params)


### PR DESCRIPTION
- Removed inconsistent commands from Android demo mode setup (wifi and mobile network)
- Added demo mode for iOS side (note: For some reason iOS doesn't let us set time as 12:00, neither it let me set it up as 09:00 so I just went with 09:30 - full hour seems to be an issue) - https://stackoverflow.com/questions/79073093/unable-to-set-1200-time-in-the-ios-simulator 