### PR TITLE
Exponential time interval + emulator flags

### DIFF
--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -74,12 +74,6 @@ module Fastlane
         emulator.start_emulator(name: params[:emulator_name], port: params[:emulator_port])
         adb.trigger(command: "wait-for-device", serial: "emulator-#{params[:emulator_port]}")
 
-        UI.message("Restarting ADB server... ---------------- \n\n")
-        adb.trigger(command: "kill-server")
-        sleep(5)
-        adb.trigger(command: "start-server")
-        UI.success("ADB server restarted. ---------------- \n\n")
-
         booted = Helper::MaestroOrchestrationHelper.wait_for_emulator_to_boot(adb, 10, 3, "emulator-#{params[:emulator_port]}")
 
         unless booted

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -74,7 +74,7 @@ module Fastlane
         emulator.start_emulator(name: params[:emulator_name], port: params[:emulator_port])
         adb.trigger(command: "wait-for-device", serial: "emulator-#{params[:emulator_port]}")
 
-        booted = Helper::MaestroOrchestrationHelper.wait_for_emulator_to_boot(adb, 10, 3, "emulator-#{params[:emulator_port]}")
+        booted = Helper::MaestroOrchestrationHelper.wait_for_emulator_to_boot(adb, 10, "emulator-#{params[:emulator_port]}")
 
         unless booted
           UI.error("Emulator failed to boot after #{max_retries} attempts. Restarting ADB server...")
@@ -83,7 +83,7 @@ module Fastlane
           UI.message("ADB server restarted. Retrying boot process...")
 
           # Retry boot process after restarting ADB server
-          booted = Helper::MaestroOrchestrationHelper.wait_for_emulator_to_boot(adb, 10, 3, "emulator-#{params[:emulator_port]}")
+          booted = Helper::MaestroOrchestrationHelper.wait_for_emulator_to_boot(adb, 10, "emulator-#{params[:emulator_port]}")
         end
 
         if booted

--- a/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
@@ -14,9 +14,10 @@ module Fastlane
         UI.message("Hello from the maestro_orchestration plugin helper!")
       end
 
-      def self.wait_for_emulator_to_boot(adb, max_retries, wait_interval, serial)
+      def self.wait_for_emulator_to_boot(adb, max_retries, serial)
         retries = 0
         booted = false
+        wait_interval = 1
 
         while retries < max_retries
           result = `#{adb.adb_path} -e shell getprop sys.boot_completed`.strip
@@ -31,7 +32,11 @@ module Fastlane
 
           retries += 1
           UI.message("Retrying... Attempt #{retries}/#{max_retries}")
-          sleep(wait_interval) # Wait before retrying
+
+          wait_interval = [1 + (2**retries), 30].min
+
+          UI.message("Waiting for #{wait_interval} seconds before retrying...")
+          sleep(wait_interval)
         end
 
         booted
@@ -113,6 +118,10 @@ module Fastlane
         command = [
           "-avd #{name.shellescape}",
           "-port #{port.shellescape}",
+          "-wipe-data",
+          "-no-boot-anim",
+          "-no-snapshot",
+          "-no-audio",
           "> /dev/null 2>&1 &"
         ].join(" ")
 

--- a/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
@@ -17,7 +17,6 @@ module Fastlane
       def self.wait_for_emulator_to_boot(adb, max_retries, serial)
         retries = 0
         booted = false
-        wait_interval = 1
 
         while retries < max_retries
           result = `#{adb.adb_path} -e shell getprop sys.boot_completed`.strip


### PR DESCRIPTION
None of these flags removed issue on my local machine, but boot seems a bit faster. 
I couldn't test the interval because of the RSA key issue.