### PR TITLE
Potential support for unauthorized device issue

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -194,3 +194,5 @@ Bundler/OrderedGems:
 Gemspec/DevelopmentDependencies:
   Enabled: true
   EnforcedStyle: Gemfile
+Metrics/PerceivedComplexity:
+  Max: 10

--- a/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
@@ -131,6 +131,18 @@ module Fastlane
 
         trigger(command: command)
       end
+
+      # Delete an existing AVD
+      def delete_avd(name:)
+        raise "AVD name is required" if name.nil? || name.empty?
+
+        command = [
+          "delete avd",
+          "-n #{name.shellescape}"
+        ].join(" ")
+
+        trigger(command: command)
+      end
     end
 
     class EmulatorHelper


### PR DESCRIPTION
- I went back and checked bunch of articles, but it's essentially the same as before, everyone has their own solution (steps are similar but not the same in every case) that worked for them. Mostly talking about the actual device rather than emulator.

- Then we can go back to this: https://stackoverflow.com/a/70930282 , where they suggest to delete the `adbkey` and `adbkey.pub`. 
- That takes us to the solution that we tried to implement, coming from this: https://stackoverflow.com/questions/55208828/android-emulator-unauthorized in order to have a fresh start. Based on that I added steps to delete AVD completely, and then create it (same as what we are doing on iOS), then if that fails, instead of just restarting `adb` server, we restart the whole thing, new AVD, new emulator, new adb server. While I do believe that should give us more protection, I am not sure if that is solving the issue permanently as I couldn't find any other resources that significantly differ from these (besides manually enabling the emulator which is not an option for us).

Also there you can check the link to this issue https://androidstudio.googleblog.com/2019/03/emulator-28112-canary-28025-to-beta.html where they state it was an issue with platform tools version 28.0.2 where they suggest the same steps to fix the issue, again involving deletion of the `adbkey` files. Maybe we still have those platform tools installed and should get rid of them just in case?

Since I followed the steps on my local machine, I stopped having issues, however lastly what I could think of could maybe be the incompatibility of android studio and `commandline-tools` that we have, but I would say it's unlikely since we are launching everything with `commandline-tools`.