### PR TITLE
Testing emulator startup

### DIFF
--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -126,6 +126,8 @@ module Fastlane
         UI.message("Found APK file at: #{apk_path}")
         adb.trigger(command: "install -r '#{apk_path}'", serial: serial)
         UI.success("APK installed on Android emulator.")
+        UI.message("Installed packages:\n")
+        adb.trigger(command: "shell pm list packages", serial: serial)
       end
 
       def self.description

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -113,10 +113,14 @@ module Fastlane
         adb.load_all_devices
         serial = adb.devices.first.serial
 
+        UI.message("Generating 'assembleRelease' build...")
+        # Trigger the 'assembleRelease' build
+        system("./gradlew assembleRelease")
+        # After building, try to find the APK file in the release output directory
         apk_path = Dir["app/build/outputs/apk/release/*.apk"].first
-
+        # If still not found after building, raise an error
         if apk_path.nil?
-          UI.user_error!("Error: APK file not found in build outputs.")
+          UI.user_error!("Error: APK file not found in build outputs even after running assembleRelease.")
         end
 
         UI.message("Found APK file at: #{apk_path}")

--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -21,7 +21,7 @@ module Fastlane
 
         adb = Helper::AdbHelper.new
 
-        setup_emulator(params)
+        # setup_emulator(params)
         sleep(5)
         demo_mode(params)
         install_android_app(params)

--- a/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
@@ -227,7 +227,8 @@ module Fastlane
           "-no-boot-anim",
           "-no-snapshot",
           "-no-audio",
-          "> /dev/null 2>&1 &"
+          "> emulator_logs 2>&1 &"
+          # "> /dev/null 2>&1 &"
         ].join(" ")
 
         UI.message("Starting emulator #{name} on port #{port}...")

--- a/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
@@ -189,6 +189,9 @@ module Fastlane
         UI.message("Setting up new Android emulator...")
         create_avd(name: params[:emulator_name], package: params[:emulator_package], device: params[:emulator_device])
 
+        UI.message("Debug statement to check created AVDs")
+        UI.message(`#{avdmanager_path} list avd`)
+
         UI.message("Starting Android emulator...")
         emulator.start_emulator(name: params[:emulator_name], port: params[:emulator_port])
         adb.trigger(command: "wait-for-device", serial: "emulator-#{params[:emulator_port]}")

--- a/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/helper/maestro_orchestration_helper.rb
@@ -230,7 +230,11 @@ module Fastlane
           "-no-boot-anim",
           "-no-snapshot",
           "-no-audio",
-          "> emulator_logs 2>&1 &"
+          "-no-window",
+          "-gpu swiftshader_indirect",
+          "-verbose",
+          "-show-kernel",
+          "> emulator-log.txt 2>&1 &"
           # "> /dev/null 2>&1 &"
         ].join(" ")
 


### PR DESCRIPTION
Can we merge this, so I can push another test on the ODA side to see emulator logs?