### PR TITLE
Clean the build before generating new one

### DIFF
--- a/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
+++ b/lib/fastlane/plugin/maestro_orchestration/actions/maestro_orchestration_android_action.rb
@@ -67,6 +67,9 @@ module Fastlane
         adb.load_all_devices
         serial = adb.devices.first.serial
 
+        UI.message("Cleaning previous build outputs...")
+        system("./gradlew clean")
+
         UI.message("Generating 'assembleRelease' build...")
         # Trigger the 'assembleRelease' build
         system("./gradlew assembleRelease")


### PR DESCRIPTION
This is required for the fix that is pushed on ODA repo. Cleaning the build before generating new one should be enough to pull the new `env` values.